### PR TITLE
Add cluster metrics

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -28,3 +28,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 }
+
+resource "azurerm_role_assignment" "metrics" {
+  principal_id         = var.service_principal.id
+  scope                = azurerm_kubernetes_cluster.aks.id
+  role_definition_name = "Monitoring Metrics Publisher"
+}


### PR DESCRIPTION
This enables the ability to collect Kubernetes cluster metrics with Azure Monitor.