### PR TITLE
Add support for defining multiple subnets

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     name           = "node"
     node_count     = 1
     vm_size        = "Standard_D2_v2"
-    vnet_subnet_id = var.network.subnet.id
+    vnet_subnet_id = var.network.subnets.primary.id
   }
 
   service_principal {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -26,9 +26,9 @@ variable "network" {
     resource_group = object({
       id = string
     })
-    subnet = object({
+    subnets = map(object({
       id = string
-    })
+    }))
   })
 }
 

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -4,6 +4,19 @@ terraform {
   }
 }
 
+locals {
+  address_blocks = cidrsubnets(var.address_space, 8, var.subnets.*.bits...)
+  dns_service_ip = cidrhost(local.address_blocks.0, 10)
+  service_cidr   = local.address_blocks.0
+  subnets = {
+    for index, subnet in var.subnets : subnet.name => {
+      name = subnet.name
+      cidr = local.address_blocks[index + 1]
+    }
+    if subnet.name != null
+  }
+}
+
 resource "azurerm_resource_group" "main" {
   name     = format("%s-rg", var.name)
   location = var.location
@@ -13,12 +26,13 @@ resource "azurerm_virtual_network" "main" {
   name                = format("%s-vnet", var.name)
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  address_space       = ["10.0.0.0/8"]
+  address_space       = [var.address_space]
 }
 
-resource "azurerm_subnet" "cluster" {
-  name                 = "cluster"
+resource "azurerm_subnet" "main" {
+  for_each             = local.subnets
+  name                 = each.value.name
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
-  address_prefix       = "10.240.0.0/16"
+  address_prefix       = each.value.cidr
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -8,19 +8,19 @@ output "vnet" {
   value       = azurerm_virtual_network.main
 }
 
-output "subnet" {
-  description = "The virtual network subnet"
-  value       = azurerm_subnet.cluster
+output "subnets" {
+  description = "The virtual network subnets"
+  value       = azurerm_subnet.main
 }
 
 output "dns_service_ip" {
   description = "The DNS service IP"
-  value       = "10.0.0.10"
+  value       = local.dns_service_ip
 }
 
 output "service_cidr" {
   description = "The Kubernetes service address range"
-  value       = "10.0.0.0/16"
+  value       = local.service_cidr
 }
 
 output "docker_bridge_cidr" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -7,3 +7,20 @@ variable "location" {
   description = "The resource location"
   type        = string
 }
+
+variable "address_space" {
+  description = "The virtual network address space"
+  default     = "10.0.0.0/8"
+  type        = string
+}
+
+variable "subnets" {
+  description = "The virtual network subnet configuration"
+  default = [
+    { name = "primary", bits = 8 }
+  ]
+  type = list(object({
+    name = string
+    bits = number
+  }))
+}


### PR DESCRIPTION
This adds support for defining multiple custom subnets in the network submodule but does not yet support pass-through configuration for the main module.