### PR TITLE
Add live data monitoring integration

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.41"
+    azurerm    = ">= 1.41"
+    kubernetes = ">= 1.10"
   }
 }
 
@@ -105,4 +106,34 @@ resource "azurerm_role_assignment" "monitor" {
   principal_id         = var.service_principal.id
   scope                = azurerm_kubernetes_cluster.main.id
   role_definition_name = "Monitoring Metrics Publisher"
+}
+
+resource "kubernetes_cluster_role" "monitor" {
+  metadata {
+    name = "aks-monitor"
+  }
+
+  rule {
+    api_groups = ["", "metrics.k8s.io", "extensions", "apps"]
+    resources  = ["pods", "pods/log", "events", "nodes", "deployments", "replicasets"]
+    verbs      = ["get", "list", "top"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "monitor" {
+  metadata {
+    name = "aks-monitor"
+  }
+
+  role_ref {
+    name      = "aks-monitor"
+    kind      = "ClusterRole"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  subject {
+    name      = "clusterUser"
+    kind      = "User"
+    api_group = "rbac.authorization.k8s.io"
+  }
 }


### PR DESCRIPTION
This adds a Kubernetes cluster role and cluster role binding for the monitoring of live data from the cluster.