### PR TITLE
Add role-based access control admin binding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "cluster" {
   rbac_server_application = module.rbac_server_application
   rbac_client_application = module.rbac_client_application
   dns_prefix              = var.dns_prefix
+  administrators          = var.administrators
 
   pools = {
     for name, pool in var.pools : name => {

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -187,7 +187,7 @@ resource "kubernetes_cluster_role_binding" "admin" {
   }
 
   role_ref {
-    name      = "aks-admin"
+    name      = kubernetes_cluster_role.admin.metadata.0.name
     kind      = "ClusterRole"
     api_group = "rbac.authorization.k8s.io"
   }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -1,5 +1,6 @@
 terraform {
   required_providers {
+    azuread    = ">= 0.7"
     azurerm    = ">= 1.41"
     kubernetes = ">= 1.10"
   }
@@ -134,6 +135,66 @@ resource "kubernetes_cluster_role_binding" "monitor" {
   subject {
     name      = "clusterUser"
     kind      = "User"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+locals {
+  administrators = zipmap(var.administrators, var.administrators)
+}
+
+data "azuread_user" "admin" {
+  for_each            = local.administrators
+  user_principal_name = each.value
+}
+
+resource "azuread_group" "admin" {
+  name = "Kubernetes Administrators"
+}
+
+resource "azuread_group_member" "admin" {
+  for_each         = data.azuread_user.admin
+  group_object_id  = azuread_group.admin.id
+  member_object_id = each.value.id
+}
+
+resource "azurerm_role_assignment" "admin" {
+  principal_id         = azuread_group.admin.id
+  scope                = azurerm_kubernetes_cluster.main.id
+  role_definition_name = "Azure Kubernetes Service Cluster Admin Role"
+}
+
+resource "kubernetes_cluster_role" "admin" {
+  metadata {
+    name = "aks-admin"
+  }
+
+  rule {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["*"]
+  }
+
+  rule {
+    non_resource_urls = ["*"]
+    verbs             = ["*"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "admin" {
+  metadata {
+    name = "aks-admin"
+  }
+
+  role_ref {
+    name      = "aks-admin"
+    kind      = "ClusterRole"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  subject {
+    name      = azuread_group.admin.id
+    kind      = "Group"
     api_group = "rbac.authorization.k8s.io"
   }
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -87,3 +87,9 @@ variable "rbac_client_application" {
     id = string
   })
 }
+
+variable "administrators" {
+  description = "The cluster administrator user email addresses"
+  default     = []
+  type        = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -35,3 +35,9 @@ variable "pools" {
   }
   type = map(any)
 }
+
+variable "administrators" {
+  description = "The cluster administrator user email addresses"
+  default     = []
+  type        = list(string)
+}


### PR DESCRIPTION
This adds a role-based access control binding for a new _Kubernetes Administrators_ group with the ability to include users by email address.