### PR TITLE
Add cluster credentials

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -5,6 +5,11 @@ locals {
   }
 }
 
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 resource "azurerm_resource_group" "main" {
   name     = format("%s-rg", var.name)
   location = var.location
@@ -42,6 +47,14 @@ resource "azurerm_kubernetes_cluster" "main" {
       client_app_id     = var.rbac_client_application.id
       server_app_id     = var.rbac_server_application.id
       server_app_secret = var.rbac_server_application.secret
+    }
+  }
+
+  linux_profile {
+    admin_username = "aks"
+
+    ssh_key {
+      key_data = tls_private_key.ssh.public_key_openssh
     }
   }
 

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -2,3 +2,15 @@ output "kubernetes" {
   description = "The Kubernetes configuration"
   value       = azurerm_kubernetes_cluster.main.kube_config.0
 }
+
+output "ssh_public_key" {
+  description = "The SSH public key"
+  value       = tls_private_key.ssh.public_key_pem
+  sensitive   = true
+}
+
+output "ssh_private_key" {
+  description = "The SSH private key"
+  value       = tls_private_key.ssh.private_key_pem
+  sensitive   = true
+}

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -3,5 +3,6 @@ terraform {
     azuread    = ">= 0.7"
     azurerm    = ">= 1.41"
     kubernetes = ">= 1.10"
+    tls        = ">= 2.1"
   }
 }


### PR DESCRIPTION
This adds the username and SSH key credentials for the Azure Kubernetes Service cluster.

The official resource documentation recommends against generating a private key inside Terraform due to it being stored unencrypted inside the Terraform state file. However this advice is redundant when the Kubernetes resource stores sensitive data that could also compromise the host nodes.