### PR TITLE
Move role assignments to appropriate modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,11 @@ module "service_principal" {
 }
 
 module "registry" {
-  source     = "./modules/registry"
-  name       = format("%s-registry", var.name)
-  location   = var.location
-  dns_prefix = var.dns_prefix
+  source            = "./modules/registry"
+  name              = format("%s-registry", var.name)
+  location          = var.location
+  dns_prefix        = var.dns_prefix
+  service_principal = module.service_principal
 }
 
 module "monitor" {
@@ -22,10 +23,11 @@ module "monitor" {
 }
 
 module "network" {
-  source     = "./modules/network"
-  name       = format("%s-network", var.name)
-  location   = var.location
-  dns_prefix = var.dns_prefix
+  source            = "./modules/network"
+  name              = format("%s-network", var.name)
+  location          = var.location
+  dns_prefix        = var.dns_prefix
+  service_principal = module.service_principal
 
   subnets = [
     for subnet in var.subnets : {

--- a/modules/cluster/network.tf
+++ b/modules/cluster/network.tf
@@ -1,5 +1,0 @@
-resource "azurerm_role_assignment" "network" {
-  principal_id         = var.service_principal.id
-  scope                = var.network.resource_group.id
-  role_definition_name = "Network Contributor"
-}

--- a/modules/cluster/registry.tf
+++ b/modules/cluster/registry.tf
@@ -1,5 +1,0 @@
-resource "azurerm_role_assignment" "registry" {
-  principal_id         = var.service_principal.id
-  scope                = var.registry.resource_group.id
-  role_definition_name = "AcrPull"
-}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -39,3 +39,9 @@ resource "azurerm_public_ip" "main" {
   allocation_method   = "Static"
   domain_name_label   = var.dns_prefix
 }
+
+resource "azurerm_role_assignment" "main" {
+  principal_id         = var.service_principal.id
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "Network Contributor"
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -29,3 +29,10 @@ variable "subnets" {
     bits = number
   }))
 }
+
+variable "service_principal" {
+  description = "The service principal"
+  type = object({
+    id = string
+  })
+}

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -10,3 +10,9 @@ resource "azurerm_container_registry" "main" {
   sku                 = var.sku
   admin_enabled       = true
 }
+
+resource "azurerm_role_assignment" "main" {
+  principal_id         = var.service_principal.id
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "AcrPull"
+}

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -18,3 +18,10 @@ variable "dns_prefix" {
   description = "The DNS prefix"
   type        = string
 }
+
+variable "service_principal" {
+  description = "The service principal"
+  type = object({
+    id = string
+  })
+}


### PR DESCRIPTION
This moves role assignments for network and container registry access to the relevant submodules in order to keep related resources together.