### PR TITLE
Remove redundant network parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,11 +26,10 @@ module "monitor" {
 }
 
 module "network" {
-  source            = "./modules/network"
-  name              = format("%s-network", var.name)
-  location          = var.location
-  dns_prefix        = var.dns_prefix
-  service_principal = module.service_principal
+  source     = "./modules/network"
+  name       = format("%s-network", var.name)
+  location   = var.location
+  dns_prefix = var.dns_prefix
 
   subnets = [
     for subnet in var.subnets : {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -29,10 +29,3 @@ variable "subnets" {
     bits = number
   }))
 }
-
-variable "service_principal" {
-  description = "The service principal"
-  type = object({
-    id = string
-  })
-}


### PR DESCRIPTION
This removes the redundant network service principal parameter left over from a previous update.