### PR TITLE
Add role-based access control group configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,14 @@ module "rbac" {
   name    = format("%s-rbac", var.name)
   consent = false
   enabled = try(var.rbac.enabled, true)
+
+  groups = {
+    admin = {
+      label   = "Azure Kubernetes Service Administrators"
+      members = try(var.rbac.administrators, [])
+      enabled = try(var.rbac.enabled, true) && length(try(var.rbac.administrators, [])) > 0
+    }
+  }
 }
 
 module "cluster" {
@@ -51,7 +59,6 @@ module "cluster" {
   service_principal = module.service_principal
   rbac              = module.rbac
   dns_prefix        = var.dns_prefix
-  administrators    = var.administrators
 
   pools = {
     for name, pool in var.pools : name => {

--- a/modules/cluster/rbac/main.tf
+++ b/modules/cluster/rbac/main.tf
@@ -1,35 +1,15 @@
-locals {
-  administrators = var.enabled ? zipmap(var.administrators, var.administrators) : {}
-}
-
-data "azuread_user" "main" {
-  for_each            = local.administrators
-  user_principal_name = each.value
-}
-
-resource "azuread_group" "main" {
-  count = var.enabled ? 1 : 0
-  name  = "Kubernetes Administrators"
-}
-
-resource "azuread_group_member" "main" {
-  for_each         = data.azuread_user.main
-  group_object_id  = azuread_group.main.0.id
-  member_object_id = each.value.id
-}
-
 resource "azurerm_role_assignment" "main" {
-  count                = var.enabled ? 1 : 0
-  principal_id         = azuread_group.main.0.id
+  for_each             = var.groups
+  principal_id         = each.value.id
   scope                = var.cluster.id
   role_definition_name = "Azure Kubernetes Service Cluster Admin Role"
 }
 
 resource "kubernetes_cluster_role" "main" {
-  count = var.enabled ? 1 : 0
+  for_each = var.groups
 
   metadata {
-    name = var.name
+    name = format("%s-%s", var.name, each.key)
   }
 
   rule {
@@ -45,20 +25,20 @@ resource "kubernetes_cluster_role" "main" {
 }
 
 resource "kubernetes_cluster_role_binding" "main" {
-  count = var.enabled ? 1 : 0
+  for_each = var.groups
 
   metadata {
-    name = var.name
+    name = format("%s-%s", var.name, each.key)
   }
 
   role_ref {
-    name      = kubernetes_cluster_role.main.0.metadata.0.name
+    name      = kubernetes_cluster_role.main[each.key].metadata.0.name
     kind      = "ClusterRole"
     api_group = "rbac.authorization.k8s.io"
   }
 
   subject {
-    name      = azuread_group.main.0.id
+    name      = each.value.id
     kind      = "Group"
     api_group = "rbac.authorization.k8s.io"
   }

--- a/modules/cluster/rbac/variables.tf
+++ b/modules/cluster/rbac/variables.tf
@@ -10,10 +10,11 @@ variable "cluster" {
   })
 }
 
-variable "administrators" {
-  description = "The cluster administrator user email addresses"
-  default     = []
-  type        = list(string)
+variable "groups" {
+  description = "The group information"
+  type = map(object({
+    id = string
+  }))
 }
 
 variable "enabled" {

--- a/modules/cluster/rbac/versions.tf
+++ b/modules/cluster/rbac/versions.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    azuread    = ">= 0.7"
     azurerm    = ">= 1.42"
     kubernetes = ">= 1.10"
   }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -79,9 +79,3 @@ variable "rbac" {
   default     = null
   type        = any
 }
-
-variable "administrators" {
-  description = "The cluster administrator user email addresses"
-  default     = []
-  type        = list(string)
-}

--- a/modules/rbac/groups/main.tf
+++ b/modules/rbac/groups/main.tf
@@ -1,0 +1,50 @@
+locals {
+  groups = {
+    for key, group in var.config : key => {
+      label   = group.label
+      members = group.members
+    }
+    if group.enabled
+  }
+}
+
+resource "azuread_group" "main" {
+  for_each = local.groups
+  name     = each.value.label
+}
+
+locals {
+  user_list = distinct(flatten([
+    for group in local.groups : group.members
+  ]))
+  users = zipmap(local.user_list, local.user_list)
+}
+
+data "azuread_user" "main" {
+  for_each            = local.users
+  user_principal_name = each.value
+}
+
+locals {
+  member_list = flatten([
+    for key, group in local.groups : [
+      for member in group.members : {
+        key   = format("%s::%s", key, member)
+        user  = data.azuread_user.main[member]
+        group = azuread_group.main[key]
+      }
+    ]
+  ])
+  members = {
+    for item in local.member_list : item.key => {
+      user  = item.user
+      group = item.group
+    }
+  }
+}
+
+resource "azuread_group_member" "main" {
+  for_each         = local.members
+  group_object_id  = each.value.group.id
+  member_object_id = each.value.user.id
+}

--- a/modules/rbac/groups/outputs.tf
+++ b/modules/rbac/groups/outputs.tf
@@ -1,0 +1,21 @@
+output "config" {
+  description = "The group configuration"
+  value       = local.groups
+}
+
+output "groups" {
+  description = "The group information"
+  value = {
+    for key, group in local.groups : key => {
+      id    = azuread_group.main[key].id
+      label = group.label
+      members = {
+        for name, member in group.members : name => {
+          id    = data.azuread_user.main[member].id
+          label = data.azuread_user.main[member].display_name
+          email = data.azuread_user.main[member].user_principal_name
+        }
+      }
+    }
+  }
+}

--- a/modules/rbac/groups/variables.tf
+++ b/modules/rbac/groups/variables.tf
@@ -1,0 +1,9 @@
+variable "config" {
+  description = "The group configuration"
+  default     = {}
+  type = map(object({
+    label   = string
+    members = list(string)
+    enabled = bool
+  }))
+}

--- a/modules/rbac/groups/versions.tf
+++ b/modules/rbac/groups/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    azuread = ">= 0.7"
+  }
+}

--- a/modules/rbac/main.tf
+++ b/modules/rbac/main.tf
@@ -11,3 +11,8 @@ module "client" {
   server  = module.server
   enabled = var.enabled
 }
+
+module "groups" {
+  source = "./groups"
+  config = var.groups
+}

--- a/modules/rbac/outputs.tf
+++ b/modules/rbac/outputs.tf
@@ -8,6 +8,11 @@ output "client" {
   value       = module.client
 }
 
+output "groups" {
+  description = "The group information"
+  value       = module.groups
+}
+
 output "enabled" {
   description = "Role-based access control is enabled"
   value       = var.enabled

--- a/modules/rbac/variables.tf
+++ b/modules/rbac/variables.tf
@@ -9,6 +9,12 @@ variable "consent" {
   type        = bool
 }
 
+variable "groups" {
+  description = "The group configuration"
+  default     = null
+  type        = any
+}
+
 variable "enabled" {
   description = "Enable role-based access control"
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -36,12 +36,6 @@ variable "pools" {
   type = map(any)
 }
 
-variable "administrators" {
-  description = "The cluster administrator user email addresses"
-  default     = []
-  type        = list(string)
-}
-
 variable "registry" {
   description = "The container registry"
   type = object({


### PR DESCRIPTION
This adds internal role-based access control group configuration via the _rbac_ module and updates the cluster addon to support multiple named groups.