### PR TITLE
Move monitoring retention period to nested config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "monitor" {
   source    = "./modules/monitor"
   name      = format("%s-monitor", var.name)
   location  = var.location
-  retention = var.retention
+  retention = try(var.monitor.retention, 30)
   enabled   = try(var.monitor.enabled, true)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "dns_prefix" {
   type        = string
 }
 
-variable "retention" {
-  description = "The Log Analytics retention period in days"
-  default     = 30
-  type        = number
-}
-
 variable "subnets" {
   description = "The network subnet configuration"
   default = [


### PR DESCRIPTION
This moves the _retention_ period variable out of the root module to under the _monitor_ configuration variable.