### PR TITLE
Add random log analytics workspace name

### DIFF
--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,3 +1,12 @@
+resource "random_id" "main" {
+  count       = var.enabled ? 1 : 0
+  byte_length = 8
+
+  keepers = {
+    name = var.name
+  }
+}
+
 resource "azurerm_resource_group" "main" {
   count    = var.enabled ? 1 : 0
   name     = format("%s-rg", var.name)
@@ -6,7 +15,7 @@ resource "azurerm_resource_group" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enabled ? 1 : 0
-  name                = format("%s-la", var.name)
+  name                = format("%s-%d-la", var.name, random_id.main.0.dec)
   resource_group_name = azurerm_resource_group.main.0.name
   location            = azurerm_resource_group.main.0.location
   sku                 = "PerGB2018"

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,6 +1,6 @@
 resource "random_id" "main" {
   count       = var.enabled ? 1 : 0
-  byte_length = 8
+  byte_length = 4
 
   keepers = {
     name = var.name
@@ -15,7 +15,7 @@ resource "azurerm_resource_group" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enabled ? 1 : 0
-  name                = format("%s-%d-la", var.name, random_id.main.0.dec)
+  name                = format("%s-%s-la", var.name, substr(random_id.main.0.dec, 0, 8))
   resource_group_name = azurerm_resource_group.main.0.name
   location            = azurerm_resource_group.main.0.location
   sku                 = "PerGB2018"

--- a/modules/monitor/versions.tf
+++ b/modules/monitor/versions.tf
@@ -1,5 +1,6 @@
 terraform {
   required_providers {
     azurerm = ">= 1.41"
+    random  = ">= 2.2"
   }
 }


### PR DESCRIPTION
This adds a random decimal number to the log analytics workspace name to help ensure that it is unique across the Azure platform.