### PR TITLE
Add auto-generated cluster name suffix

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -19,14 +19,14 @@ resource "azurerm_resource_group" "main" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                = var.name == "aks" ? "aks" : format("%s-aks", var.name)
+  name                = format("%s-aks", var.name)
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  node_resource_group = format("%s-node-rg", var.name)
+  node_resource_group = var.node_resource_group_name
   dns_prefix          = var.dns_prefix
 
   default_node_pool {
-    name                = "primary"
+    name                = "nodepool"
     type                = "VirtualMachineScaleSets"
     vnet_subnet_id      = var.network.subnets.primary.id
     vm_size             = var.pools.primary.size
@@ -156,7 +156,7 @@ locals {
 
 module "rbac" {
   source  = "./rbac"
-  name    = format("%s-cluster", var.name)
+  name    = format("%s-rbac", var.name)
   groups  = local.groups
   cluster = azurerm_kubernetes_cluster.main
   enabled = local.rbac_enabled

--- a/modules/cluster/suffix/main.tf
+++ b/modules/cluster/suffix/main.tf
@@ -1,0 +1,6 @@
+data "external" "main" {
+  program = ["${path.module}/scripts/suffix.sh"]
+  query = {
+    input = var.input
+  }
+}

--- a/modules/cluster/suffix/outputs.tf
+++ b/modules/cluster/suffix/outputs.tf
@@ -1,0 +1,4 @@
+output "output" {
+  description = "The cluster suffix"
+  value       = data.external.main.result.output
+}

--- a/modules/cluster/suffix/scripts/suffix.sh
+++ b/modules/cluster/suffix/scripts/suffix.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+case "$OSTYPE" in
+  linux*)
+    mkdir -p ./.terraform
+    cd ./.terraform
+
+    curl -s https://api.github.com/repos/dbalcomb/aks-cluster-suffix/releases/latest \
+    | grep "browser_download_url.*x86_64-unknown-linux-gnu.tar.gz\"" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | wget -q -i - -O - \
+    | tar -xz
+
+    exec ./aks-cluster-suffix
+  ;;
+  darwin*)
+    mkdir -p ./.terraform
+    cd ./.terraform
+
+    curl -s https://api.github.com/repos/dbalcomb/aks-cluster-suffix/releases/latest \
+    | grep "browser_download_url.*x86_64-apple-darwin.tar.gz\"" \
+    | cut -d : -f 2,3 \
+    | tr -d \" \
+    | wget -q -i - -O - \
+    | tar -xz
+
+    exec ./aks-cluster-suffix
+  ;;
+  *)
+    echo "unsupported operating system: $OSTYPE" 1>&2
+    exit 1
+  ;;
+esac

--- a/modules/cluster/suffix/variables.tf
+++ b/modules/cluster/suffix/variables.tf
@@ -1,0 +1,4 @@
+variable "input" {
+  description = "The input variable"
+  type        = string
+}

--- a/modules/cluster/suffix/versions.tf
+++ b/modules/cluster/suffix/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.41"
+    external = ">= 1.2"
   }
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -82,3 +82,8 @@ variable "dashboard" {
   default     = null
   type        = any
 }
+
+variable "node_resource_group_name" {
+  description = "The node resource group name"
+  type        = string
+}

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,12 +1,3 @@
-resource "random_id" "main" {
-  count       = var.enabled ? 1 : 0
-  byte_length = 4
-
-  keepers = {
-    name = var.name
-  }
-}
-
 resource "azurerm_resource_group" "main" {
   count    = var.enabled ? 1 : 0
   name     = format("%s-rg", var.name)
@@ -15,7 +6,7 @@ resource "azurerm_resource_group" "main" {
 
 resource "azurerm_log_analytics_workspace" "main" {
   count               = var.enabled ? 1 : 0
-  name                = format("%s-%s-la", var.name, substr(random_id.main.0.dec, 0, 8))
+  name                = format("%s-la", var.name)
   resource_group_name = azurerm_resource_group.main.0.name
   location            = azurerm_resource_group.main.0.location
   sku                 = "PerGB2018"


### PR DESCRIPTION
This adds an auto-generated cluster name suffix to each resource.

This is an initial implementation that uses an external utility to generate the suffix using a cut down version of the algorithm used by the *aks-engine* project. The generated suffix should match the one that is given to cluster resources by *Azure* but is not otherwise accessible by Terraform.

The downside of this approach is that it is currently only supported on Linux and macOS due to the use of a bash script to download and run the tool. Other solutions include:

- Require users to manually use the tool and pass the generated suffix as a variable.
- Require users to install the utility and call it as an external program.
- Wrap the Terraform setup with a bash script and generate the suffix before the plan.
- Publish a new provider with a custom resource to get the name.
- Use the HTTP provider and provision a web server with a custom endpoint.

The simplest solution for end-users would be to use the HTTP provider but this would require maintenance and hosting costs.

The custom provider would likely be the best option if only there was better support for automatically installing third-party providers.