### PR TITLE
Add kured integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ module "cluster" {
   rbac              = module.rbac
   dns_prefix        = var.dns_prefix
   dashboard         = var.dashboard
+  kured             = var.kured
 
   node_resource_group_name = format("%s-nodepool-%s-rg", var.name, module.suffix.output)
 

--- a/modules/cluster/kured/main.tf
+++ b/modules/cluster/kured/main.tf
@@ -1,0 +1,16 @@
+resource "helm_release" "main" {
+  count     = var.enabled ? 1 : 0
+  name      = var.name
+  namespace = "kube-system"
+  chart     = "stable/kured"
+
+  set {
+    name  = "nodeSelector.beta\\.kubernetes\\.io/os"
+    value = "linux"
+  }
+
+  set {
+    name  = "autolock.enabled"
+    value = true
+  }
+}

--- a/modules/cluster/kured/variables.tf
+++ b/modules/cluster/kured/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "The resource name"
+  type        = string
+}
+
+variable "enabled" {
+  description = "Enable kured"
+  default     = true
+  type        = bool
+}

--- a/modules/cluster/kured/versions.tf
+++ b/modules/cluster/kured/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    helm = ">= 1.0"
+  }
+}

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -2,6 +2,7 @@ locals {
   rbac_enabled      = try(var.rbac.enabled, true)
   monitor_enabled   = try(var.monitor.enabled, true)
   dashboard_enabled = try(var.dashboard.enabled, true)
+  kured_enabled     = try(var.kured.enabled, true)
   pools = {
     for name, pool in var.pools : name => pool
     if name != "primary"
@@ -160,4 +161,10 @@ module "rbac" {
   groups  = local.groups
   cluster = azurerm_kubernetes_cluster.main
   enabled = local.rbac_enabled
+}
+
+module "kured" {
+  source  = "./kured"
+  name    = format("%s-kured", var.name)
+  enabled = local.kured_enabled
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -83,6 +83,12 @@ variable "dashboard" {
   type        = any
 }
 
+variable "kured" {
+  description = "The kured configuration"
+  default     = null
+  type        = any
+}
+
 variable "node_resource_group_name" {
   description = "The node resource group name"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,9 @@ variable "ingress" {
   default     = null
   type        = any
 }
+
+variable "kured" {
+  description = "The kured configuration"
+  default     = null
+  type        = any
+}


### PR DESCRIPTION
This installs the *kured* helm chart to handle the installation of node security updates and restarting of the underlying virtual machines.