### PR TITLE
Add basic example

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,19 @@
+module "acr" {
+  source     = "github.com/dbalcomb/terraform-azurerm-acr"
+  name       = "acr"
+  location   = "uksouth"
+  dns_prefix = "dbalcombacr"
+}
+
+module "aks" {
+  source     = "../../" # github.com/dbalcomb/terraform-azurerm-aks
+  name       = "aks"
+  location   = "uksouth"
+  dns_prefix = "dbalcombaks"
+  registry   = module.acr
+
+  rbac = {
+    enabled        = true
+    administrators = ["daniel.balcomb@outlook.com"]
+  }
+}


### PR DESCRIPTION
This adds a basic example implementation with a single role-based access control administrator.