### PR TITLE
Add terraform plan continuous integration workflow

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -1,0 +1,32 @@
+name: plan
+on:
+  pull_request:
+    paths:
+    - '**.tf'
+    - .github/workflows/plan.yml
+  push:
+    branches:
+    - master
+jobs:
+  example:
+    name: example / ${{ matrix.example }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'dbalcomb/terraform-azurerm-aks'
+    strategy:
+      matrix:
+        example:
+        - basic
+    steps:
+    - uses: actions/checkout@v2
+    - uses: volcano-coffee-company/setup-terraform@v1
+      with:
+        version: ~0.12.20
+    - run: terraform init -input=false -backend=false
+      working-directory: ./examples/${{ matrix.example }}
+    - run: terraform plan -input=false
+      working-directory: ./examples/${{ matrix.example }}
+      env:
+        ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+        ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+        ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+        ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -13,7 +13,9 @@ module "aks" {
   registry   = module.acr
 
   rbac = {
-    enabled        = true
-    administrators = ["daniel.balcomb@outlook.com"]
+    enabled = true
+    administrators = [
+      "daniel.balcomb_outlook.com#EXT#@danielbalcomboutlook.onmicrosoft.com",
+    ]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = ">= 0.12.20"
+
+  required_providers {
+    kubernetes = "= 1.10"
+  }
 }


### PR DESCRIPTION
This adds a continuous integration workflow for running plans on examples. This should uncover any issues not found by the linting and validation checks as well as test any bash scripts.