### PR TITLE
Add kubernetes and helm provider configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,25 @@
+provider "kubernetes" {
+  host                   = module.cluster.kubernetes.host
+  username               = module.cluster.kubernetes.username
+  password               = module.cluster.kubernetes.password
+  client_certificate     = base64decode(module.cluster.kubernetes.client_certificate)
+  client_key             = base64decode(module.cluster.kubernetes.client_key)
+  cluster_ca_certificate = base64decode(module.cluster.kubernetes.cluster_ca_certificate)
+  load_config_file       = false
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.cluster.kubernetes.host
+    username               = module.cluster.kubernetes.username
+    password               = module.cluster.kubernetes.password
+    client_certificate     = base64decode(module.cluster.kubernetes.client_certificate)
+    client_key             = base64decode(module.cluster.kubernetes.client_key)
+    cluster_ca_certificate = base64decode(module.cluster.kubernetes.cluster_ca_certificate)
+    load_config_file       = false
+  }
+}
+
 module "service_principal" {
   source = "./modules/service-principal"
   name   = var.name


### PR DESCRIPTION
This adds pre-configured providers for *kubernetes* and *helm* to ensure that configuration from the cluster is used instead of anything user-provided.

This requirement went unnoticed in the local setup due to the existence of pre-existing *kubernetes* configuration on disk.