### PR TITLE
Add prometheus metrics integration

### DIFF
--- a/modules/cluster/kured/main.tf
+++ b/modules/cluster/kured/main.tf
@@ -13,4 +13,19 @@ resource "helm_release" "main" {
     name  = "autolock.enabled"
     value = true
   }
+
+  set {
+    name  = "podAnnotations.prometheus\\.io/scrape"
+    value = "true"
+  }
+
+  set {
+    name  = "podAnnotations.prometheus\\.io/path"
+    value = "/metrics"
+  }
+
+  set {
+    name  = "podAnnotations.prometheus\\.io/port"
+    value = "8080"
+  }
 }

--- a/modules/cluster/monitor/main.tf
+++ b/modules/cluster/monitor/main.tf
@@ -38,3 +38,17 @@ resource "kubernetes_cluster_role_binding" "main" {
     api_group = "rbac.authorization.k8s.io"
   }
 }
+
+resource "kubernetes_config_map" "main" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name      = var.name
+    namespace = "kube-system"
+  }
+
+  data = {
+    "schema-version"                      = "v1"
+    "prometheus-data-collection-settings" = file("${path.module}/templates/prometheus.tpl")
+  }
+}

--- a/modules/cluster/monitor/templates/prometheus.tpl
+++ b/modules/cluster/monitor/templates/prometheus.tpl
@@ -1,0 +1,3 @@
+[prometheus_data_collection_settings.cluster]
+  interval = "1m"
+  monitor_kubernetes_pods = true

--- a/modules/ingress/main.tf
+++ b/modules/ingress/main.tf
@@ -36,4 +36,24 @@ resource "helm_release" "main" {
     name  = "defaultBackend.nodeSelector.beta\\.kubernetes\\.io/os"
     value = "linux"
   }
+
+  set {
+    name  = "controller.metrics.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "controller.metrics.service.annotations.prometheus\\.io/scrape"
+    value = "true"
+  }
+
+  set {
+    name  = "controller.metrics.service.annotations.prometheus\\.io/path"
+    value = "/metrics"
+  }
+
+  set {
+    name  = "controller.metrics.service.annotations.prometheus\\.io/port"
+    value = "10254"
+  }
 }


### PR DESCRIPTION
This adds *Prometheus* metrics collection via *Azure Monitor* for the *ingress* and *kured* helm charts.