### PR TITLE
Add container log collection settings

### DIFF
--- a/modules/cluster/monitor/main.tf
+++ b/modules/cluster/monitor/main.tf
@@ -50,5 +50,13 @@ resource "kubernetes_config_map" "main" {
   data = {
     "schema-version"                      = "v1"
     "prometheus-data-collection-settings" = file("${path.module}/templates/prometheus.tpl")
+    "log-data-collection-settings" = templatefile("${path.module}/templates/log.tpl", {
+      envvar_enabled            = false
+      enrich_enabled            = false
+      stdout_enabled            = false
+      stdout_exclude_namespaces = ["kube-system"]
+      stderr_enabled            = true
+      stderr_exclude_namespaces = ["kube-system"]
+    })
   }
 }

--- a/modules/cluster/monitor/templates/log.tpl
+++ b/modules/cluster/monitor/templates/log.tpl
@@ -1,0 +1,11 @@
+[log_collection_settings]
+  [log_collection_settings.stdout]
+    enabled = ${stdout_enabled}
+    exclude_namespaces = [%{ for ns in stdout_exclude_namespaces ~}"${ns}"%{ endfor ~}]
+  [log_collection_settings.stderr]
+    enabled = ${stderr_enabled}
+    exclude_namespaces = [%{ for ns in stderr_exclude_namespaces ~}"${ns}"%{ endfor ~}]
+  [log_collection_settings.env_var]
+    enabled = ${envvar_enabled}
+  [log_collection_settings.enrich_container_logs]
+    enabled = ${enrich_enabled}


### PR DESCRIPTION
This adds container log collection settings to disable the collection of *stdout* logs and environment variables while leaving *stderr* for debugging purposes.