### PR TITLE
Add missing rbac client reply urls

### DIFF
--- a/modules/rbac/client/README.md
+++ b/modules/rbac/client/README.md
@@ -3,6 +3,13 @@
 This module configures the Role-Based Access Control (RBAC) client component
 that handles authentication with the Kubernetes CLI (`kubectl`).
 
+## Notes
+
+- The client component uses a list of reply URLs for authentication as gathered
+  from Microsoft documentation and the `aks-commander` project.
+
 ## References
 
+- [AAD Client Application](https://docs.microsoft.com/en-gb/azure/aks/azure-ad-integration)
 - [AAD Client Component](https://docs.microsoft.com/en-gb/azure/aks/azure-ad-integration-cli#create-azure-ad-client-component)
+- [AKS Commander](https://github.com/rhummelmose/aks-commander/blob/master/terraform/rbac/main.tf#L15)

--- a/modules/rbac/client/README.md
+++ b/modules/rbac/client/README.md
@@ -13,3 +13,4 @@ that handles authentication with the Kubernetes CLI (`kubectl`).
 - [AAD Client Application](https://docs.microsoft.com/en-gb/azure/aks/azure-ad-integration)
 - [AAD Client Component](https://docs.microsoft.com/en-gb/azure/aks/azure-ad-integration-cli#create-azure-ad-client-component)
 - [AKS Commander](https://github.com/rhummelmose/aks-commander/blob/master/terraform/rbac/main.tf#L15)
+- [Desktop App Registration](https://docs.microsoft.com/en-gb/azure/active-directory/develop/scenario-desktop-app-registration)

--- a/modules/rbac/client/main.tf
+++ b/modules/rbac/client/main.tf
@@ -7,8 +7,14 @@ resource "azuread_application" "main" {
   count         = var.enabled ? 1 : 0
   name          = var.name
   type          = "native"
-  reply_urls    = [format("https://%s", var.name)]
   public_client = true
+
+  reply_urls = [
+    "https://${var.name}",
+    "https://login.microsoftonline.com/common/oauth2/nativeclient",
+    "https://afd.hosting.portal.azure.net/monitoring/Content/iframe/infrainsights.app/web/base-libs/auth/auth.html",
+    "https://monitoring.hosting.portal.azure.net/monitoring/Content/iframe/infrainsights.app/web/base-libs/auth/auth.html",
+  ]
 
   required_resource_access {
     resource_app_id = var.server.id


### PR DESCRIPTION
This adds missing reply URLs for the RBAC client component that are required to enable integration with Azure Monitor for Containers.

It also includes a *nativeclient* URL that is documented on the `aks-commander` project that is not listed in the Microsoft documentation. This may be superfluous.