### PR TITLE
Tweak cluster autoscaler configuration

### DIFF
--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -20,3 +20,4 @@ the various add-on modules that can be used to add extra functionality.
 ## References
 
 - [Azure Kubernetes Service Tutorial](https://docs.microsoft.com/en-gb/azure/aks/tutorial-kubernetes-deploy-cluster)
+- [Cluster Autoscaler](https://docs.microsoft.com/en-gb/azure/aks/cluster-autoscaler)

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -50,7 +50,7 @@ variable "pools" {
   default = {
     primary = {}
   }
-  type = map(any)
+  type = any
 }
 
 variable "rbac" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "pools" {
   default = {
     primary = {}
   }
-  type = map(any)
+  type = any
 }
 
 variable "registry" {


### PR DESCRIPTION
This tweaks the cluster autoscaler configuration to allow for multiple syntax options.

* Set the *scale* option to a number to disable autoscaling.
* Set the *scale* option to a map with optional *min* and *max* autoscaling values.
* Set the *scale* option to a string with a value in the format of *x-y* to configure min and max options.