### PR TITLE
Persist kubernetes configuration file to disk

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -135,6 +135,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "main" {
   }
 }
 
+resource "local_file" "kubeconfig" {
+  filename          = "${path.cwd}/kubeconfig"
+  file_permission   = "0644"
+  sensitive_content = azurerm_kubernetes_cluster.main.kube_config_raw
+}
+
 locals {
   dashboard = {
     name    = format("%s-dashboard", var.name)

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
     azurerm = ">= 1.42"
+    local   = ">= 1.4"
     tls     = ">= 2.1"
   }
 }

--- a/modules/ingress/cert-manager/main.tf
+++ b/modules/ingress/cert-manager/main.tf
@@ -12,11 +12,11 @@ resource "null_resource" "definitions" {
   }
 
   provisioner "local-exec" {
-    command = "kubectl apply -f ${path.module}/templates/definitions.yml"
+    command = "kubectl apply -f ${path.module}/templates/definitions.yml --kubeconfig ${path.cwd}/kubeconfig"
   }
 
   provisioner "local-exec" {
-    command = "kubectl delete -f ${path.module}/templates/definitions.yml"
+    command = "kubectl delete -f ${path.module}/templates/definitions.yml --kubeconfig ${path.cwd}/kubeconfig"
     when    = destroy
   }
 }


### PR DESCRIPTION
This persists the Kubernetes configuration file to disk in order for `local-exec` provisioners to access the cluster with the correct credentials.