### PR TITLE
Fix incorrect rbac application identifier

### DIFF
--- a/modules/rbac/client/outputs.tf
+++ b/modules/rbac/client/outputs.tf
@@ -1,6 +1,6 @@
 output "id" {
   description = "The application identifier"
-  value       = try(azuread_application.main.0.id, null)
+  value       = try(azuread_application.main.0.application_id, null)
 }
 
 output "service_principal" {

--- a/modules/rbac/server/outputs.tf
+++ b/modules/rbac/server/outputs.tf
@@ -1,6 +1,6 @@
 output "id" {
   description = "The application identifier"
-  value       = try(azuread_application.main.0.id, null)
+  value       = try(azuread_application.main.0.application_id, null)
 }
 
 output "scopes" {


### PR DESCRIPTION
This fixes role-based access control for the cluster by using the client and server application identifiers instead of the object identifiers.