### PR TITLE
Rename cluster service principal

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ provider "helm" {
 
 module "service_principal" {
   source = "./modules/service-principal"
-  name   = var.name
+  name   = local.cluster.name
 
   role_assignments = {
     network = {


### PR DESCRIPTION
This renames the cluster service principal to match the name of the cluster with the generated suffix.