### PR TITLE
Fix rbac kubernetes authentication

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -138,7 +138,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "main" {
 resource "local_file" "kubeconfig" {
   filename          = "${path.cwd}/kubeconfig"
   file_permission   = "0644"
-  sensitive_content = azurerm_kubernetes_cluster.main.kube_config_raw
+  sensitive_content = local.rbac.enabled ? azurerm_kubernetes_cluster.main.kube_admin_config_raw : azurerm_kubernetes_cluster.main.kube_config_raw
 }
 
 locals {

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -1,6 +1,6 @@
 output "kubernetes" {
   description = "The Kubernetes configuration"
-  value       = azurerm_kubernetes_cluster.main.kube_config.0
+  value       = local.rbac.enabled ? azurerm_kubernetes_cluster.main.kube_admin_config.0 : azurerm_kubernetes_cluster.main.kube_config.0
 }
 
 output "ssh_public_key" {


### PR DESCRIPTION
This fixes Kubernetes authentication with role-based access control enabled clusters by using the Kubernetes admin configuration.