### PR TITLE
Fix invalid kubernetes dashboard cluster role binding

### DIFF
--- a/modules/cluster/dashboard/main.tf
+++ b/modules/cluster/dashboard/main.tf
@@ -212,6 +212,5 @@ resource "kubernetes_cluster_role_binding" "main" {
     name      = "kubernetes-dashboard"
     namespace = "kube-system"
     kind      = "ServiceAccount"
-    api_group = "rbac.authorization.k8s.io"
   }
 }


### PR DESCRIPTION
This fixes the invalid Kubernetes dashboard cluster role binding which mistakenly included an `api_group` for a *ServiceAccount* subject.