### PR TITLE
Fix ingress controller load balancer annotation

### DIFF
--- a/modules/ingress/controller/main.tf
+++ b/modules/ingress/controller/main.tf
@@ -30,7 +30,7 @@ resource "helm_release" "main" {
   }
 
   set {
-    name  = "controller.service.annotations.service.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
     value = var.resource_group_name
   }
 


### PR DESCRIPTION
This fixes the ingress controller load balancer service by escaping a dot in the annotation name.