### PR TITLE
Fix ingress and egress ip address conflict

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,11 +162,10 @@ locals {
 }
 
 module "ingress" {
-  source              = "./modules/ingress"
-  name                = local.ingress.name
-  ip_address          = module.network.ip.ip_address
-  resource_group_name = module.network.resource_group.name
-  replicas            = local.ingress.replicas
-  routes              = local.ingress.routes
-  enabled             = local.ingress.enabled
+  source   = "./modules/ingress"
+  name     = local.ingress.name
+  network  = module.network
+  replicas = local.ingress.replicas
+  routes   = local.ingress.routes
+  enabled  = local.ingress.enabled
 }

--- a/modules/ingress/README.md
+++ b/modules/ingress/README.md
@@ -9,7 +9,18 @@ handling in the Azure Kubernetes Service (AKS) cluster.
 - [Controller](controller/README.md)
 - [Routes](routes/README.md)
 
-## Resources
+## Notes
+
+- Shared IP addresses for ingress and egress are not currently supported. This
+  means that the controller needs to be assigned a new separate IP.
+
+## References
 
 - [AKS Networking Ingress](https://docs.microsoft.com/en-gb/azure/aks/concepts-network#ingress-controllers)
 - [Standard SKU Load Balancer](https://docs.microsoft.com/en-gb/azure/aks/load-balancer-standard)
+- [Shared Public IP](https://github.com/kubernetes-sigs/cloud-provider-azure/issues/267)
+- [Static IP Conflict](https://github.com/Azure/AKS/issues/1359)
+- [IP Per Service](https://github.com/MicrosoftDocs/azure-docs/issues/10816#issuecomment-400851710)
+- [Egress Traffic Overview](https://docs.microsoft.com/en-gb/azure/aks/egress#egress-traffic-overview)
+- [Load Balancer Error](https://stackoverflow.com/questions/49994073/load-balancer-publicipreferencedbymultipleipconfigs-error-on-restart)
+- [Multiple IP References](https://github.com/Azure/ACS/issues/102)

--- a/modules/ingress/controller/main.tf
+++ b/modules/ingress/controller/main.tf
@@ -4,6 +4,14 @@ data "helm_repository" "main" {
   url   = "https://kubernetes-charts.storage.googleapis.com"
 }
 
+resource "azurerm_public_ip" "main" {
+  name                = format("%s-ip", var.name)
+  location            = var.network.resource_group.location
+  resource_group_name = var.network.resource_group.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
 resource "kubernetes_namespace" "main" {
   count = var.enabled ? 1 : 0
 
@@ -26,12 +34,12 @@ resource "helm_release" "main" {
 
   set {
     name  = "controller.service.loadBalancerIP"
-    value = var.ip_address
+    value = azurerm_public_ip.main.ip_address
   }
 
   set {
     name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
-    value = var.resource_group_name
+    value = var.network.resource_group.name
   }
 
   set {

--- a/modules/ingress/controller/variables.tf
+++ b/modules/ingress/controller/variables.tf
@@ -3,20 +3,20 @@ variable "name" {
   type        = string
 }
 
+variable "network" {
+  description = "The network configuration"
+  type = object({
+    resource_group = object({
+      name     = string
+      location = string
+    })
+  })
+}
+
 variable "replicas" {
   description = "The ingress controller replica count"
   default     = 1
   type        = number
-}
-
-variable "ip_address" {
-  description = "The ingress controller load balancer IP address"
-  type        = string
-}
-
-variable "resource_group_name" {
-  description = "The ingress controller load balancer resource group name"
-  type        = string
 }
 
 variable "enabled" {

--- a/modules/ingress/main.tf
+++ b/modules/ingress/main.tf
@@ -1,10 +1,9 @@
 module "controller" {
-  source              = "./controller"
-  name                = var.name
-  replicas            = var.replicas
-  ip_address          = var.ip_address
-  resource_group_name = var.resource_group_name
-  enabled             = var.enabled
+  source   = "./controller"
+  name     = var.name
+  network  = var.network
+  replicas = var.replicas
+  enabled  = var.enabled
 }
 
 module "routes" {

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -3,20 +3,20 @@ variable "name" {
   type        = string
 }
 
+variable "network" {
+  description = "The network configuration"
+  type = object({
+    resource_group = object({
+      name     = string
+      location = string
+    })
+  })
+}
+
 variable "replicas" {
   description = "The ingress controller replica count"
   default     = 1
   type        = number
-}
-
-variable "ip_address" {
-  description = "The ingress controller load balancer IP address"
-  type        = string
-}
-
-variable "resource_group_name" {
-  description = "The ingress controller load balancer resource group name"
-  type        = string
 }
 
 variable "routes" {


### PR DESCRIPTION
This fixes the IP address conflict where a single IP address cannot be used for both ingress and egress. The solution was to provision a new IP address along with the ingress controller.