### PR TITLE
Fix incorrectly named monitor settings config map

### DIFF
--- a/modules/cluster/monitor/main.tf
+++ b/modules/cluster/monitor/main.tf
@@ -43,7 +43,7 @@ resource "kubernetes_config_map" "main" {
   count = var.enabled ? 1 : 0
 
   metadata {
-    name      = var.name
+    name      = "container-azm-ms-agentconfig"
     namespace = "kube-system"
   }
 


### PR DESCRIPTION
This fixes the incorrectly named config map which configures prometheus and log collection settings. However it does not address omsagent errors that cannot connect to the *kured* pod when it is locked.