### PR TITLE
Fix kured support on newer kubernetes versions

### DIFF
--- a/modules/cluster/kured/main.tf
+++ b/modules/cluster/kured/main.tf
@@ -12,6 +12,11 @@ resource "helm_release" "main" {
   chart      = "kured"
 
   set {
+    name  = "image.tag"
+    value = "master-f6e4062"
+  }
+
+  set {
     name  = "nodeSelector.beta\\.kubernetes\\.io/os"
     value = "linux"
   }


### PR DESCRIPTION
This updates the `kured` container tag to a newer release that supports Kubernetes versions from v1.16. This should be updated again when `kured` 1.3.0 is released.