### PR TITLE
Replace kured chart autolock with time arguments

### DIFF
--- a/modules/cluster/kured/README.md
+++ b/modules/cluster/kured/README.md
@@ -12,10 +12,11 @@ updates and restarting of Kubernetes host nodes.
   budgets to prevent this but the impact will be that host nodes are unable to
   restart to complete security updates.
 - The Helm chart includes the ability to limit restarts to a certain time
-  period. This happens to be between 4am and 6am.
+  period. This happens to be between 2am and 4am.
 
 ## References
 
+- [Kured Configuration](https://github.com/weaveworks/kured#configuration)
 - [Using Kured](https://docs.microsoft.com/en-gb/azure/aks/node-updates-kured)
 - [Helm Install](https://github.com/MicrosoftDocs/azure-docs/pull/45988)
 - [Helm Chart](https://github.com/helm/charts/tree/master/stable/kured)

--- a/modules/cluster/kured/main.tf
+++ b/modules/cluster/kured/main.tf
@@ -22,8 +22,18 @@ resource "helm_release" "main" {
   }
 
   set {
-    name  = "autolock.enabled"
-    value = true
+    name  = "extraArgs.time-zone"
+    value = "Local"
+  }
+
+  set {
+    name  = "extraArgs.start-time"
+    value = "2am"
+  }
+
+  set {
+    name  = "extraArgs.end-time"
+    value = "4am"
   }
 
   set {


### PR DESCRIPTION
This refactors the `kured` configuration to use the native restart time arguments since updating to the latest release. The benefit of this is that it removes the need for additional resources to lock and unlock nodes.

This also updates the allowed restart times from 4am-6am to 2am-4am based on local time.