### PR TITLE
Add cluster autoscaler diagnostics collection

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -165,6 +165,7 @@ module "monitor" {
   source            = "./monitor"
   name              = format("%s-monitor", var.name)
   cluster           = azurerm_kubernetes_cluster.main
+  monitor           = var.monitor
   service_principal = var.service_principal
   enabled           = local.monitor.enabled
 }

--- a/modules/cluster/monitor/main.tf
+++ b/modules/cluster/monitor/main.tf
@@ -60,3 +60,70 @@ resource "kubernetes_config_map" "main" {
     })
   }
 }
+
+resource "azurerm_monitor_diagnostic_setting" "main" {
+  count                      = var.enabled ? 1 : 0
+  name                       = "diagnostics"
+  target_resource_id         = var.cluster.id
+  log_analytics_workspace_id = var.monitor.log_analytics_workspace.id
+
+  log {
+    category = "cluster-autoscaler"
+    enabled  = true
+
+    retention_policy {
+      days    = 30
+      enabled = true
+    }
+  }
+
+  log {
+    category = "kube-apiserver"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "kube-audit"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "kube-controller-manager"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "kube-scheduler"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}

--- a/modules/cluster/monitor/variables.tf
+++ b/modules/cluster/monitor/variables.tf
@@ -10,6 +10,12 @@ variable "cluster" {
   })
 }
 
+variable "monitor" {
+  description = "The monitor information"
+  default     = null
+  type        = any
+}
+
 variable "service_principal" {
   description = "The service principal"
   type = object({


### PR DESCRIPTION
This enables the collection of the `cluster-autoscaler` diagnostics when monitoring is enabled. A follow-up pull request should be made to separate diagnostics from monitoring.