### PR TITLE
Lock maximum azurerm provider version

### DIFF
--- a/modules/cluster/monitor/versions.tf
+++ b/modules/cluster/monitor/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm    = ">= 1.42"
+    azurerm    = ">= 1.42, < 2.0"
     kubernetes = ">= 1.10"
   }
 }

--- a/modules/cluster/rbac/versions.tf
+++ b/modules/cluster/rbac/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm    = ">= 1.42"
+    azurerm    = ">= 1.42, < 2.0"
     kubernetes = ">= 1.10"
   }
 }

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.42"
+    azurerm = ">= 1.42, < 2.0"
     local   = ">= 1.4"
     tls     = ">= 2.1"
   }

--- a/modules/monitor/versions.tf
+++ b/modules/monitor/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.41"
+    azurerm = ">= 1.42, < 2.0"
   }
 }

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.41"
+    azurerm = ">= 1.42, < 2.0"
   }
 }


### PR DESCRIPTION
This limits the `azurerm` provider version to not use version `2.0` which introduced the insane idea of requiring an empty `features` provider block simply to inform users of its existence.

On its own this would not be a problem as documentation and examples can be updated to include it. However it also breaks validation of modules that should not include an `azurerm` provider block and follow official Terraform documentation to not lock the maximum version.