### PR TITLE
Fix ingress controller prometheus annotations

### DIFF
--- a/modules/ingress/controller/main.tf
+++ b/modules/ingress/controller/main.tf
@@ -58,17 +58,17 @@ resource "helm_release" "main" {
   }
 
   set {
-    name  = "controller.metrics.service.annotations.prometheus\\.io/scrape"
+    name  = "controller.podAnnotations.prometheus\\.io/scrape"
     value = "true"
   }
 
   set {
-    name  = "controller.metrics.service.annotations.prometheus\\.io/path"
+    name  = "controller.podAnnotations.prometheus\\.io/path"
     value = "/metrics"
   }
 
   set {
-    name  = "controller.metrics.service.annotations.prometheus\\.io/port"
+    name  = "controller.podAnnotations.prometheus\\.io/port"
     value = "10254"
   }
 }


### PR DESCRIPTION
This fixes the metrics collection for the ingress controller by annotating the controller pods instead of the metrics service.