### PR TITLE
Fix incompatible ingress route namespace

### DIFF
--- a/examples/ingress/main.tf
+++ b/examples/ingress/main.tf
@@ -19,6 +19,7 @@ module "aks" {
     enabled = true
     routes = {
       example = {
+        namespace = "example"
         rules = [
           {
             host = "example.com"

--- a/modules/ingress/routes/README.md
+++ b/modules/ingress/routes/README.md
@@ -7,6 +7,8 @@ the ingress controller.
 
 - At this time there is no support for the `rewrite-target` annotation or for
   specifying certificate information.
+- It is not currently possible, for security reasons, to define an ingress
+  resource in a separate namespace to the backend service.
 
 ## References
 

--- a/modules/ingress/routes/main.tf
+++ b/modules/ingress/routes/main.tf
@@ -3,7 +3,7 @@ resource "kubernetes_ingress" "main" {
 
   metadata {
     name      = format("%s-%s", var.controller.name, each.key)
-    namespace = var.controller.namespace
+    namespace = each.value.namespace
 
     annotations = {
       "kubernetes.io/ingress.class" = "nginx"

--- a/modules/ingress/routes/variables.tf
+++ b/modules/ingress/routes/variables.tf
@@ -9,6 +9,7 @@ variable "controller" {
 variable "routes" {
   description = "The route configuration"
   type = map(object({
+    namespace = string
     rules = list(object({
       host = string
       paths = list(object({

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -23,6 +23,7 @@ variable "routes" {
   description = "The ingress route configuration"
   default     = {}
   type = map(object({
+    namespace = string
     rules = list(object({
       host = string
       paths = list(object({


### PR DESCRIPTION
This fixes the error where an ingress route cannot see the backend service due to it being in a separate namespace.