### PR TITLE
Make container registry integration optional

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,15 +1,7 @@
-module "acr" {
-  source     = "github.com/dbalcomb/terraform-azurerm-acr"
-  name       = "acr"
-  location   = "uksouth"
-  dns_prefix = "dbalcombacr"
-}
-
 module "aks" {
   source   = "../../" # github.com/dbalcomb/terraform-azurerm-aks
   name     = "aks"
   location = "uksouth"
-  registry = module.acr
 
   network = {
     dns_prefix = "dbalcombaks"

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ module "service_principal" {
       scope = module.network.resource_group.id
       role  = "Network Contributor"
     }
-    registry = {
+    registry = var.registry == null ? null : {
       scope = var.registry.resource_group.id
       role  = "AcrPull"
     }

--- a/modules/service-principal/main.tf
+++ b/modules/service-principal/main.tf
@@ -1,3 +1,9 @@
+locals {
+  role_assignments = {
+    for key, val in var.role_assignments : key => val if val != null
+  }
+}
+
 resource "azuread_application" "main" {
   name                       = var.name
   type                       = "webapp/api"
@@ -23,7 +29,7 @@ resource "azuread_service_principal_password" "secret" {
 }
 
 resource "azurerm_role_assignment" "main" {
-  for_each             = var.role_assignments
+  for_each             = local.role_assignments
   principal_id         = azuread_service_principal.main.id
   scope                = each.value.scope
   role_definition_name = each.value.role

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,7 @@ variable "location" {
 
 variable "registry" {
   description = "The container registry"
+  default     = null
   type = object({
     id = string
     resource_group = object({


### PR DESCRIPTION
This makes the Azure container registry integration optional and therefore allows the registry to be created at a later date if needed.