### PR TITLE
Update azurerm provider version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,8 +8,8 @@ on:
     branches:
     - master
 jobs:
-  validate:
-    name: validate
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -17,8 +17,6 @@ jobs:
       with:
         version: ~0.12.20
     - run: terraform fmt -check -diff -recursive
-    - run: terraform init -backend=false
-    - run: terraform validate
 
   example:
     name: example / ${{ matrix.example }}
@@ -34,6 +32,8 @@ jobs:
       with:
         version: ~0.12.20
     - run: terraform init -input=false -backend=false
+      working-directory: ./examples/${{ matrix.example }}
+    - run: terraform validate
       working-directory: ./examples/${{ matrix.example }}
     - run: terraform plan -input=false
       working-directory: ./examples/${{ matrix.example }}

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -1,0 +1,3 @@
+provider "azurerm" {
+  features {}
+}

--- a/modules/cluster/monitor/versions.tf
+++ b/modules/cluster/monitor/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm    = ">= 1.42, < 2.0"
+    azurerm    = ">= 2.5"
     kubernetes = ">= 1.10"
   }
 }

--- a/modules/cluster/rbac/versions.tf
+++ b/modules/cluster/rbac/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm    = ">= 1.42, < 2.0"
+    azurerm    = ">= 2.5"
     kubernetes = ">= 1.10"
   }
 }

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.42, < 2.0"
+    azurerm = ">= 2.5"
     local   = ">= 1.4"
     tls     = ">= 2.1"
   }

--- a/modules/monitor/versions.tf
+++ b/modules/monitor/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.42, < 2.0"
+    azurerm = ">= 2.5"
   }
 }

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    azurerm = ">= 1.42, < 2.0"
+    azurerm = ">= 2.5"
   }
 }


### PR DESCRIPTION
This updates the `azurerm` provider version to the latest `2.5` release. This should fix the issues relating to the `windows_profile` block causing the cluster to be re-created.

However it has the unintended side effect of requiring a change to the `validate` workflow job because the developers of the provider are insistent of requiring an empty `features` block in the provider simply to make users aware of its existence. This means that it is impossible to validate the root module itself without including a provider and this is unacceptable for a public module. Despite many protests the developers have made their minds and the onus is on the *Terraform* developers to fix validation in such scenarios which may take several more years.