### PR TITLE
Exclude excessive prometheus metrics

### DIFF
--- a/modules/cluster/monitor/main.tf
+++ b/modules/cluster/monitor/main.tf
@@ -48,8 +48,50 @@ resource "kubernetes_config_map" "main" {
   }
 
   data = {
-    "schema-version"                      = "v1"
-    "prometheus-data-collection-settings" = file("${path.module}/templates/prometheus.tpl")
+    "schema-version" = "v1"
+    "prometheus-data-collection-settings" = templatefile("${path.module}/templates/prometheus.tpl", {
+      fields_exclude = var.debug ? [] : [
+        "go_gc_duration_seconds",
+        "go_gc_duration_seconds_count",
+        "go_gc_duration_seconds_sum",
+        "go_goroutines",
+        "go_info",
+        "go_memstats_alloc_bytes",
+        "go_memstats_alloc_bytes_total",
+        "go_memstats_buck_hash_sys_bytes",
+        "go_memstats_frees_total",
+        "go_memstats_gc_cpu_fraction",
+        "go_memstats_gc_sys_bytes",
+        "go_memstats_heap_alloc_bytes",
+        "go_memstats_heap_idle_bytes",
+        "go_memstats_heap_inuse_bytes",
+        "go_memstats_heap_objects",
+        "go_memstats_heap_released_bytes",
+        "go_memstats_heap_sys_bytes",
+        "go_memstats_last_gc_time_seconds",
+        "go_memstats_lookups_total",
+        "go_memstats_mallocs_total",
+        "go_memstats_mcache_inuse_bytes",
+        "go_memstats_mcache_sys_bytes",
+        "go_memstats_mspan_inuse_bytes",
+        "go_memstats_mspan_sys_bytes",
+        "go_memstats_next_gc_bytes",
+        "go_memstats_other_sys_bytes",
+        "go_memstats_stack_inuse_bytes",
+        "go_memstats_stack_sys_bytes",
+        "go_memstats_sys_bytes",
+        "go_threads",
+        "process_cpu_seconds_total",
+        "process_max_fds",
+        "process_open_fds",
+        "process_resident_memory_bytes",
+        "process_start_time_seconds",
+        "process_virtual_memory_bytes",
+        "process_virtual_memory_max_bytes",
+        "promhttp_metric_handler_requests_in_flight",
+        "promhttp_metric_handler_requests_total",
+      ]
+    })
     "log-data-collection-settings" = templatefile("${path.module}/templates/log.tpl", {
       envvar_enabled            = false
       enrich_enabled            = false

--- a/modules/cluster/monitor/templates/prometheus.tpl
+++ b/modules/cluster/monitor/templates/prometheus.tpl
@@ -1,3 +1,8 @@
 [prometheus_data_collection_settings.cluster]
   interval = "1m"
   monitor_kubernetes_pods = true
+  fielddrop = [
+    %{~ for field in fields_exclude ~}
+    "${field}",
+    %{~ endfor ~}
+  ]


### PR DESCRIPTION
This excludes various prometheus metric fields that are too excessive for production use. The cost of including these metrics adds up and can cause the Log Analytics data ingestion to go over the daily allowance.

For example metrics pertaining to garbage collection or file descriptors used by `go` are not necessary. Similarly memory usage that is already covered by pod metrics should not be included.

The result of this change should be that the only prometheus metric collected from this module is `kured_reboot_required` for the ability to provide alerts if nodes are unable to reboot for extended periods of time.

These metrics can be re-enabled by setting the cluster to debug mode. 