### PR TITLE
Fix log collection namespace exclusion

### DIFF
--- a/modules/cluster/monitor/templates/log.tpl
+++ b/modules/cluster/monitor/templates/log.tpl
@@ -1,10 +1,18 @@
 [log_collection_settings]
   [log_collection_settings.stdout]
     enabled = ${stdout_enabled}
-    exclude_namespaces = [%{ for ns in stdout_exclude_namespaces ~}"${ns}"%{ endfor ~}]
+    exclude_namespaces = [
+      %{~ for namespace in stdout_exclude_namespaces ~}
+      "${namespace}",
+      %{~ endfor ~}
+    ]
   [log_collection_settings.stderr]
     enabled = ${stderr_enabled}
-    exclude_namespaces = [%{ for ns in stderr_exclude_namespaces ~}"${ns}"%{ endfor ~}]
+    exclude_namespaces = [
+      %{~ for namespace in stderr_exclude_namespaces ~}
+      "${namespace}",
+      %{~ endfor ~}
+    ]
   [log_collection_settings.env_var]
     enabled = ${envvar_enabled}
   [log_collection_settings.enrich_container_logs]


### PR DESCRIPTION
This fixes the log collection settings template for excluding Kubernetes namespaces by adding the missing comma between values. It also formats the settings for the scenario of including long lists of values.

This does not actually alter any current functionality as the excluded namespaces are currently hard-coded to a single entry. However in the case of adding another entry or allowing user-defined values the template would have been broken and not be picked up by the validate/plan/apply process.