### PR TITLE
Set Kubernetes configuration output as sensitive

### DIFF
--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -21,6 +21,7 @@ output "region" {
 output "kubernetes" {
   description = "The Kubernetes configuration"
   value       = local.rbac.enabled ? azurerm_kubernetes_cluster.main.kube_admin_config.0 : azurerm_kubernetes_cluster.main.kube_config.0
+  sensitive   = true
 }
 
 output "kubeconfig" {


### PR DESCRIPTION
This sets the Kubernetes configuration output as sensitive to prevent it from being recorded in continuous integration logs.