### PR TITLE
Set service principal secret output sensitive

### DIFF
--- a/modules/service-principal/outputs.tf
+++ b/modules/service-principal/outputs.tf
@@ -21,4 +21,5 @@ output "display_name" {
 output "secret" {
   description = "The client secret / application password"
   value       = azuread_service_principal_password.secret.value
+  sensitive   = true
 }


### PR DESCRIPTION
This sets the service principal secret output to sensitive to prevent it from being displayed in logs.