### PR TITLE
Update container registry integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "service_principal" {
       role  = "Network Contributor"
     }
     registry = var.registry == null ? null : {
-      scope = var.registry.resource_group.id
+      scope = var.registry.id
       role  = "AcrPull"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,6 @@ variable "registry" {
   default     = null
   type = object({
     id = string
-    resource_group = object({
-      id = string
-    })
   })
 }
 


### PR DESCRIPTION
This updates the Azure container registry integration to use the registry ID instead of the resource group ID.