### PR TITLE
Upgrade terraform and provider versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: volcano-coffee-company/setup-terraform@v1
+    - name: Install terraform
+      uses: hashicorp/setup-terraform@v1
       with:
-        version: ~0.12.20
+        terraform_version: 1.0.10
     - run: terraform fmt -check -diff -recursive
 
   example:
@@ -28,9 +29,10 @@ jobs:
         - basic
     steps:
     - uses: actions/checkout@v2
-    - uses: volcano-coffee-company/setup-terraform@v1
+    - name: Install terraform
+      uses: hashicorp/setup-terraform@v1
       with:
-        version: ~0.12.20
+        terraform_version: 1.0.10
     - run: terraform init -input=false -backend=false
       working-directory: ./examples/${{ matrix.example }}
     - run: terraform validate

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Terraform modules for [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-gb/services/kubernetes-service/).
 
+## Upgrade
+
+Upgrading to use the `azurerm` provider 2.0 requires the following commands as
+the `user_impersonation` scope is no longer automatically provided. The scope
+identifiers can be obtained from the existing state.
+
+```sh
+terraform import module.${MODULE_NAME}.module.service_principal.random_uuid.user_impersonation_scope ${SCOPE_ID_1}
+terraform import module.${MODULE_NAME}.module.rbac.module.server.random_uuid.user_impersonation_scope ${SCOPE_ID_2}
+```
+
 ## Modules
 
 This project provides the following submodules to configure the cluster:

--- a/modules/cluster/dashboard/versions.tf
+++ b/modules/cluster/dashboard/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    kubernetes = ">= 1.10"
+    kubernetes = "~> 2.6"
   }
 }

--- a/modules/cluster/kured/main.tf
+++ b/modules/cluster/kured/main.tf
@@ -1,14 +1,8 @@
-data "helm_repository" "main" {
-  count = var.enabled ? 1 : 0
-  name  = "stable"
-  url   = "https://kubernetes-charts.storage.googleapis.com"
-}
-
 resource "helm_release" "main" {
   count      = var.enabled ? 1 : 0
   name       = var.name
   namespace  = "kube-system"
-  repository = data.helm_repository.main.0.metadata.0.name
+  repository = "https://weaveworks.github.io/kured"
   chart      = "kured"
 
   set {

--- a/modules/cluster/kured/versions.tf
+++ b/modules/cluster/kured/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    helm = ">= 1.0"
+    helm = "~> 2.3"
   }
 }

--- a/modules/cluster/monitor/versions.tf
+++ b/modules/cluster/monitor/versions.tf
@@ -1,6 +1,8 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azurerm    = ">= 2.5"
-    kubernetes = ">= 1.10"
+    azurerm    = "~> 2.83"
+    kubernetes = "~> 2.6"
   }
 }

--- a/modules/cluster/rbac/versions.tf
+++ b/modules/cluster/rbac/versions.tf
@@ -1,6 +1,8 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azurerm    = ">= 2.5"
-    kubernetes = ">= 1.10"
+    azurerm    = "~> 2.83"
+    kubernetes = "~> 2.6"
   }
 }

--- a/modules/cluster/suffix/versions.tf
+++ b/modules/cluster/suffix/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    http = ">= 1.1"
+    http = "~> 2.1"
   }
 }

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -1,7 +1,9 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azurerm = ">= 2.5"
-    local   = ">= 1.4"
-    tls     = ">= 2.1"
+    azurerm = "~> 2.83"
+    local   = "~> 2.1"
+    tls     = "~> 3.1"
   }
 }

--- a/modules/monitor/versions.tf
+++ b/modules/monitor/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azurerm = ">= 2.5"
+    azurerm = "~> 2.83"
   }
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "main" {
   name                 = each.value.name
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
-  address_prefix       = each.value.cidr
+  address_prefixes     = [each.value.cidr]
   service_endpoints    = ["Microsoft.Sql"]
 }
 

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azurerm = ">= 2.5"
+    azurerm = "~> 2.83"
   }
 }

--- a/modules/rbac/client/versions.tf
+++ b/modules/rbac/client/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azuread = ">= 0.7"
+    azuread = "~> 2.8"
   }
 }

--- a/modules/rbac/groups/main.tf
+++ b/modules/rbac/groups/main.tf
@@ -9,8 +9,9 @@ locals {
 }
 
 resource "azuread_group" "main" {
-  for_each = local.groups
-  name     = each.value.label
+  for_each         = local.groups
+  display_name     = each.value.label
+  security_enabled = true
 }
 
 locals {

--- a/modules/rbac/groups/versions.tf
+++ b/modules/rbac/groups/versions.tf
@@ -1,5 +1,7 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azuread = ">= 0.7"
+    azuread = "~> 2.8"
   }
 }

--- a/modules/rbac/server/main.tf
+++ b/modules/rbac/server/main.tf
@@ -4,7 +4,7 @@ data "azuread_service_principal" "aad" {
 }
 
 locals {
-  aad_scopes = { for item in try(data.azuread_service_principal.aad.0.oauth2_permissions, []) : item.value => item.id }
+  aad_scopes = try(data.azuread_service_principal.aad.0.oauth2_permission_scope_ids, {})
 }
 
 data "azuread_service_principal" "graph" {
@@ -13,16 +13,40 @@ data "azuread_service_principal" "graph" {
 }
 
 locals {
-  graph_roles  = { for item in try(data.azuread_service_principal.graph.0.app_roles, []) : item.value => item.id }
-  graph_scopes = { for item in try(data.azuread_service_principal.graph.0.oauth2_permissions, []) : item.value => item.id }
+  graph_roles  = try(data.azuread_service_principal.graph.0.app_role_ids, {})
+  graph_scopes = try(data.azuread_service_principal.graph.0.oauth2_permission_scope_ids, {})
 }
+
+resource "random_uuid" "user_impersonation_scope" {}
 
 resource "azuread_application" "main" {
   count                   = var.enabled ? 1 : 0
-  name                    = var.name
-  type                    = "webapp/api"
+  display_name            = var.name
   identifier_uris         = [format("https://%s", var.name)]
-  group_membership_claims = "All"
+  group_membership_claims = ["All"]
+
+  api {
+    oauth2_permission_scope {
+      admin_consent_description  = format("Allow the application to access %s on behalf of the signed-in user.", var.name)
+      admin_consent_display_name = format("Access %s", var.name)
+      id                         = random_uuid.user_impersonation_scope.result
+      enabled                    = true
+      type                       = "User"
+      user_consent_description   = format("Allow the application to access %s on your behalf.", var.name)
+      user_consent_display_name  = format("Access %s", var.name)
+      value                      = "user_impersonation"
+    }
+  }
+
+  web {
+    homepage_url  = format("https://%s", var.name)
+    redirect_uris = []
+
+    implicit_grant {
+      access_token_issuance_enabled = false
+      id_token_issuance_enabled     = true
+    }
+  }
 
   required_resource_access {
     resource_app_id = data.azuread_service_principal.aad.0.application_id
@@ -58,20 +82,9 @@ resource "azuread_service_principal" "main" {
   application_id = azuread_application.main.0.application_id
 }
 
-resource "random_password" "secret" {
-  count  = var.enabled ? 1 : 0
-  length = 48
-
-  keepers = {
-    id = azuread_service_principal.main.0.id
-  }
-}
-
 resource "azuread_service_principal_password" "secret" {
   count                = var.enabled ? 1 : 0
   service_principal_id = azuread_service_principal.main.0.id
-  value                = random_password.secret.0.result
-  end_date             = "2299-12-31T00:00:00Z"
 }
 
 resource "null_resource" "consent" {

--- a/modules/rbac/server/outputs.tf
+++ b/modules/rbac/server/outputs.tf
@@ -5,7 +5,7 @@ output "id" {
 
 output "scopes" {
   description = "The OAuth 2.0 permission scopes"
-  value       = try(azuread_application.main.0.oauth2_permissions, null)
+  value       = try(azuread_application.main.0.oauth2_permission_scope_ids, null)
 }
 
 output "secret" {

--- a/modules/rbac/server/versions.tf
+++ b/modules/rbac/server/versions.tf
@@ -1,7 +1,9 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azuread = ">= 0.7"
-    null    = ">= 2.1"
-    random  = ">= 2.2"
+    azuread = "~> 2.8"
+    null    = "~> 3.1"
+    random  = "~> 3.1"
   }
 }

--- a/modules/service-principal/main.tf
+++ b/modules/service-principal/main.tf
@@ -4,28 +4,41 @@ locals {
   }
 }
 
+resource "random_uuid" "user_impersonation_scope" {}
+
 resource "azuread_application" "main" {
-  name                       = var.name
-  type                       = "webapp/api"
-  available_to_other_tenants = false
+  display_name = var.name
+
+  api {
+    oauth2_permission_scope {
+      admin_consent_description  = format("Allow the application to access %s on behalf of the signed-in user.", var.name)
+      admin_consent_display_name = format("Access %s", var.name)
+      id                         = random_uuid.user_impersonation_scope.result
+      enabled                    = true
+      type                       = "User"
+      user_consent_description   = format("Allow the application to access %s on your behalf.", var.name)
+      user_consent_display_name  = format("Access %s", var.name)
+      value                      = "user_impersonation"
+    }
+  }
+
+  web {
+    homepage_url  = format("https://%s", var.name)
+    redirect_uris = []
+
+    implicit_grant {
+      access_token_issuance_enabled = false
+      id_token_issuance_enabled     = true
+    }
+  }
 }
 
 resource "azuread_service_principal" "main" {
   application_id = azuread_application.main.application_id
 }
 
-resource "random_password" "secret" {
-  length = 48
-
-  keepers = {
-    id = azuread_service_principal.main.id
-  }
-}
-
 resource "azuread_service_principal_password" "secret" {
   service_principal_id = azuread_service_principal.main.id
-  value                = random_password.secret.result
-  end_date             = "2299-12-31T00:00:00Z"
 }
 
 resource "azurerm_role_assignment" "main" {

--- a/modules/service-principal/versions.tf
+++ b/modules/service-principal/versions.tf
@@ -1,6 +1,8 @@
 terraform {
+  required_version = "~> 1.0"
+
   required_providers {
-    azuread = ">= 0.7"
-    random  = ">= 2.2"
+    azuread = "~> 2.8"
+    random  = "~> 3.1"
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -5,7 +5,6 @@ provider "kubernetes" {
   client_certificate     = base64decode(module.cluster.kubernetes.client_certificate)
   client_key             = base64decode(module.cluster.kubernetes.client_key)
   cluster_ca_certificate = base64decode(module.cluster.kubernetes.cluster_ca_certificate)
-  load_config_file       = false
 }
 
 provider "helm" {
@@ -16,6 +15,5 @@ provider "helm" {
     client_certificate     = base64decode(module.cluster.kubernetes.client_certificate)
     client_key             = base64decode(module.cluster.kubernetes.client_key)
     cluster_ca_certificate = base64decode(module.cluster.kubernetes.cluster_ca_certificate)
-    load_config_file       = false
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,9 @@
 terraform {
-  required_version = ">= 0.12.20"
+  required_version = "~> 1.0"
 
   required_providers {
-    kubernetes = "= 1.10"
+    azurerm    = "~> 2.83"
+    helm       = "~> 2.3"
+    kubernetes = "~> 2.6"
   }
 }


### PR DESCRIPTION
This upgrades the terraform and provider version constraints and updates the various resources to be compatible with the previous versions.

There are some notable changes:

* The `azuread_application` resource no longer provides the default `user_impersonation` scope and in order to maintain compatibility this requires manually importing any existing scope identifiers to a new `random_uuid` resource so that the existing scope can be maintained.
* The `azuread_service_principal_password` resource no longer allows a value and so the corresponding `random_password` resource has been removed.