### PR TITLE
Remove monitor cluster role and role binding

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -148,14 +148,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "main" {
 
 locals {
   monitor = {
-    name    = format("%s-monitor", var.name)
     enabled = try(var.monitor.enabled, true)
   }
 }
 
 module "monitor" {
   source            = "./monitor"
-  name              = format("%s-monitor", var.name)
   cluster           = azurerm_kubernetes_cluster.main
   monitor           = var.monitor
   service_principal = var.service_principal

--- a/modules/cluster/monitor/main.tf
+++ b/modules/cluster/monitor/main.tf
@@ -5,40 +5,6 @@ resource "azurerm_role_assignment" "main" {
   role_definition_name = "Monitoring Metrics Publisher"
 }
 
-resource "kubernetes_cluster_role" "main" {
-  count = var.enabled ? 1 : 0
-
-  metadata {
-    name = var.name
-  }
-
-  rule {
-    api_groups = ["", "metrics.k8s.io", "extensions", "apps"]
-    resources  = ["pods", "pods/log", "events", "nodes", "deployments", "replicasets"]
-    verbs      = ["get", "list", "top"]
-  }
-}
-
-resource "kubernetes_cluster_role_binding" "main" {
-  count = var.enabled ? 1 : 0
-
-  metadata {
-    name = var.name
-  }
-
-  role_ref {
-    name      = kubernetes_cluster_role.main.0.metadata.0.name
-    kind      = "ClusterRole"
-    api_group = "rbac.authorization.k8s.io"
-  }
-
-  subject {
-    name      = "clusterUser"
-    kind      = "User"
-    api_group = "rbac.authorization.k8s.io"
-  }
-}
-
 resource "kubernetes_config_map" "main" {
   count = var.enabled ? 1 : 0
 

--- a/modules/cluster/monitor/variables.tf
+++ b/modules/cluster/monitor/variables.tf
@@ -1,8 +1,3 @@
-variable "name" {
-  description = "The resource name"
-  type        = string
-}
-
 variable "cluster" {
   description = "The cluster"
   type = object({


### PR DESCRIPTION
This removes the redundant monitor cluster role and cluster role binding kubernetes resources now that the cluster is AKS-managed.